### PR TITLE
fix(getVersion): add support for different podspec format

### DIFF
--- a/lib/podspec-bumper.js
+++ b/lib/podspec-bumper.js
@@ -6,7 +6,7 @@
 var fs = require("fs");
 var path = require("path");
 var semver = require("semver");
-var VERSION_REGEXP = /s\.version\s*=\s*["'](.*?)["']/i;
+var VERSION_REGEXP = /\.version\s*=\s*["'](.*?)["']/i;
 function PodspecBumper(filePath) {
     this.filePath = filePath;
     this.fileContent = fs.readFileSync(path.resolve(process.cwd(), filePath), "utf-8");

--- a/test/fixtures/example-different-format.podspec
+++ b/test/fixtures/example-different-format.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |spec|
+  spec.name         = 'Reachability'
+  spec.version      = '3.1.0'
+  spec.license      = { :type => 'BSD' }
+  spec.homepage     = 'https://github.com/tonymillion/Reachability'
+  spec.authors      = { 'Tony Million' => 'tonymillion@gmail.com' }
+  spec.summary      = 'ARC and GCD Compatible Reachability Class for iOS and OS X.'
+  spec.source       = { :git => 'https://github.com/tonymillion/Reachability.git', :tag => 'v3.1.0' }
+  spec.source_files = 'Reachability.{h,m}'
+  spec.framework    = 'SystemConfiguration'
+end

--- a/test/podspec-bump-test.js
+++ b/test/podspec-bump-test.js
@@ -17,6 +17,13 @@ describe("podspec-bump-test", function () {
         it("should return 0.1.0", function () {
             assert.equal(podspecBumper.getVersion(), "0.1.0");
         });
+        context("when podspec is in a different format", function () {
+            it("should return 3.1.0", function () {
+                var differentPodspecPath = __dirname + "/fixtures/example-different-format.podspec";
+                var format2PodspecBumper = new PodSpecBump(differentPodspecPath);
+                assert.equal(format2PodspecBumper.getVersion(), "3.1.0");
+            });
+        });
     });
     describe("#incrementVersion", function () {
         context("when no args", function () {


### PR DESCRIPTION
This fixes an issue where `getVersion()` returns null when the podspec does not have `s.version`. 
If the podspec uses `spec.version`, the regex did not detect the version correctly.

The example podspec was copied from https://guides.cocoapods.org/syntax/podspec.html
